### PR TITLE
grep regex fixing duplicate pulls, docker execs into existing container...

### DIFF
--- a/bin/dumpling
+++ b/bin/dumpling
@@ -22,13 +22,12 @@ if [ "${CI-}" != true ]; then
   -e '^latest' -e '^Digest' && true
 fi
 
-(
+user="${SUDO_USER-$USER}"
 docker run -it --rm \
   -v /home:/home \
   -v /etc/passwd:/etc/passwd.host -v /etc/group:/etc/group.host \
   -v "${SSH_AUTH_SOCK}":/tmp/ssh -e SSH_AUTH_SOCK=/tmp/ssh \
-  --name $USER-dumpling \
-  -e USER="${SUDO_USER-$USER}" \
-  nyag/dumpling "$@"
-) ||
-(docker exec -it -u "${SUDO_USER-$USER}" $USER-dumpling /bin/bash)
+  --name "${user}-dumpling" \
+  -e "USER=${user}" \
+  nyag/dumpling "$@" \
+|| docker exec -it -u "$user" "${user}-dumpling"  /bin/bash

--- a/bin/dumpling
+++ b/bin/dumpling
@@ -22,9 +22,13 @@ if [ "${CI-}" != true ]; then
   -e '^latest' -e '^Digest' && true
 fi
 
-exec docker run -it --rm \
+(
+docker run -it --rm \
   -v /home:/home \
   -v /etc/passwd:/etc/passwd.host -v /etc/group:/etc/group.host \
   -v "${SSH_AUTH_SOCK}":/tmp/ssh -e SSH_AUTH_SOCK=/tmp/ssh \
+  --name $USER-dumpling \
   -e USER="${SUDO_USER-$USER}" \
   nyag/dumpling "$@"
+) ||
+(docker exec -it -u "${SUDO_USER-$USER}" $USER-dumpling /bin/bash)


### PR DESCRIPTION
if one already exists for the user, else creates new.

The carat in the grep regex was creating a new pull of dumpling.