### PR TITLE
Check if dumpling is running

### DIFF
--- a/bin/dumpling
+++ b/bin/dumpling
@@ -23,11 +23,14 @@ if [ "${CI-}" != true ]; then
 fi
 
 user="${SUDO_USER-$USER}"
-docker run -it --rm \
-  -v /home:/home -v /etc/localtime:/etc/localtime \
-  -v /etc/passwd:/etc/passwd.host -v /etc/group:/etc/group.host \
-  -v "${SSH_AUTH_SOCK}":/tmp/ssh -e SSH_AUTH_SOCK=/tmp/ssh \
-  --name "${user}-dumpling" \
-  -e "USER=${user}" \
-  nyag/dumpling "$@" \
-|| docker exec -it -u "$user" "${user}-dumpling"  /bin/bash
+name="${user}-dumpling"
+if [ -n "$(docker ps -q -f "name=${name}")" ]; then
+    exec docker exec -it -u "$user" "$name" /bin/bash
+else
+    exec docker run -it --rm \
+      -v /home:/home -v /etc/localtime:/etc/localtime \
+      -v /etc/passwd:/etc/passwd.host -v /etc/group:/etc/group.host \
+      -v "${SSH_AUTH_SOCK}":/tmp/ssh -e SSH_AUTH_SOCK=/tmp/ssh \
+      -e "USER=${user}" --name "$name" \
+      nyag/dumpling "$@"
+fi


### PR DESCRIPTION
Fixes #9. More importantly also prevents a useless docker exec
after a command in Docker run exits with a non-zero exit status.