### PR TITLE
Prune images from public registries

### DIFF
--- a/bin/docker-prune
+++ b/bin/docker-prune
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 # Remove exited containers and dangling images.
+# Also try removing images from public registries.
 # In Docker 1.13+ you can instead run `docker system prune`,
 # which also deletes volumes not attached to a container.
 
-set -eu
-
 docker ps -q -f status=exited | xargs -r docker rm
 docker images -q -f dangling=true | xargs -r docker rmi
+docker images -q 'docker.io/*' | xargs -r docker rmi
+docker images -q 'gcr.io/*' | xargs -r docker rmi


### PR DESCRIPTION
Public images can be downloaded again when needed, and will not be
deleted if in use. If we still run out of space, just run
docker-prune to see what container IDs can be stopped to free up
space.